### PR TITLE
fix serie-a regex

### DIFF
--- a/src/plugins/games/query.rs
+++ b/src/plugins/games/query.rs
@@ -102,7 +102,7 @@ impl Parser {
                 display_order: None,
             },
             Shortcut {
-                regex: Regex::new(r"^(?i)serie[ -]?a$").unwrap(),
+                regex: Regex::new(r"^(?i)serie[- ]?a$").unwrap(),
                 country: Some(String::from("Italy")),
                 competition: Some(String::from("Serie A")),
                 replace_by: vec![],


### PR DESCRIPTION
In a regex, `[ -]` is an incomplete range expression and
usually raises a regex compile error. The workaround is
to put the `-` at the beginning, since it can't be a
range in that position.

I am not sure including a space works at this point
because the query is being tokenized into words when
shortcuts are considered, but I left it in.

Hopefully this makes the "serie-a" shortcut more reliable.